### PR TITLE
Changing date/time conversion for an empty incoming date/time.

### DIFF
--- a/tick42rmdsmsg/upafieldpayload.h
+++ b/tick42rmdsmsg/upafieldpayload.h
@@ -1217,6 +1217,10 @@ struct UpaFieldPayload
                  uint32_t year = atoi(&asString[0]);
                  uint32_t month = atoi(&asString[5]) - 1;
                  uint32_t day = atoi(&asString[8]) - 1;
+                 uint32_t hour = atoi(&asString[11]);
+                 uint32_t minute = atoi(&asString[14])
+                 uint32_t second = atoi(&asString[17]);
+                 uint32_t microsecond = atoi(&asString[20]);
                  if (year != 0 && month != 0 && day != 0)
                  {
                      mamaDateTime_setEpochTimeExt(value,
@@ -1224,12 +1228,15 @@ struct UpaFieldPayload
                                                   0);
                      mamaDateTime_setHints(value, MAMA_DATE_TIME_HAS_DATE);
                  }
-                 mamaDateTime_setTime(value
-                     , atoi(&asString[11])
-                     , atoi(&asString[14])
-                     , atoi(&asString[17])
-                     , atoi(&asString[20])
-                     );
+                 if (hour != 0 && minute != 0 && second != 0 && microsecond != 0)
+                 {
+                     mamaDateTime_setTime(value
+                         , hour
+                         , minute
+                         , second
+                         , microsecond
+                         );
+                 }
              }
              return MAMA_STATUS_OK;
          case MAMA_FIELD_TYPE_BOOL:


### PR DESCRIPTION
It looks like the previous implementation of getDateTime() function conflicted with OpenMAMA's mamaDateTimeImpl_empty definition (mama/c_cpp/src/c/datetimeimpl.h) so getDataTime() did not returned a value that OpenMAMA regognizes as empty for an empty date/time string. mamaDateTime_setTime() unconditionally sets MAMA_DATE_TIME_HAS_TIME hint disregarding the input values. As a comparison, Solace bridge implementation does not call mamaDateTime_setTime() in a case of empty imput and properly constructs an empty mama_datetime_t object.